### PR TITLE
Fix geckodriver download and dojo build

### DIFF
--- a/provision/common.sh
+++ b/provision/common.sh
@@ -143,7 +143,7 @@ function install_ant() {
 }
 
 function install_geckodriver() {
-  local URL="$(curl --silent --fail --location https://github-api-proxy.gocd.org/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[] | select(.name | contains("linux64.tar.gz")) | .browser_download_url')"
+  local URL="$(curl --silent --fail --location https://github-api-proxy.gocd.org/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[] | select(.name | endswith("linux64.tar.gz")) | .browser_download_url')"
   try curl --silent --fail --location "${URL}" --output /usr/local/src/geckodriver-latest.tar.gz
   try tar -zxf /usr/local/src/geckodriver-latest.tar.gz -C /usr/local/bin
 }

--- a/provision/provision-centos.sh
+++ b/provision/provision-centos.sh
@@ -8,7 +8,7 @@ for arg in $@; do
     --contrib)
       PRIMARY_USER="dojo"
       SKIP_INTERNAL_CONFIG="yes"
-      GRADLE_OPTIONS="${GRADLE_OPTIONS} --no-daemon --max-workers 1"
+      GRADLE_OPTIONS="${GRADLE_OPTIONS} --no-daemon"
       shift
       ;;
     *)


### PR DESCRIPTION
Now there are 2 files in the releases which contain linux64.tar.gz -
there is also linux64.tar.gz.asc with signature. Download was failing
because URL variable had both urls and a space between them.